### PR TITLE
fix: gitignore test_snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 target
 .soroban
 .stellar
+test_snapshots
 
 # build output
 dist


### PR DESCRIPTION
These are auto-generated files and should not be checked into the repository