### PR TITLE
chore: Update build to use binstall

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -42,11 +42,11 @@ jobs:
           else
             echo "stellar-scaffold already installed. Clear cache to force reinstall."
           fi
+      - run: npm ci
       - run: npm run lint
       - run: npx prettier . --check
       - name: Build clients before building the project
         run: STELLAR_SCAFFOLD_ENV=development stellar-scaffold build --build-clients
-      - run: npm ci
       - run: npm run install:contracts
       - run: npm run build
       - name: Run tests

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -31,19 +31,14 @@ jobs:
         with:
           tag: testing
           network: local
-      # Debug step
-      - name: Debug Stellar container
-        run: |
-          docker ps
-          docker logs $(docker ps -q --filter ancestor=stellar/quickstart:testing)
-          curl -v http://localhost:8000/rpc || true
-
       - run: sudo apt-get update && sudo apt-get install -y libudev-dev libdbus-1-dev pkg-config
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.15.6
       - name: Check for stellar-scaffold binary
         run: |
           if ! command -v stellar-scaffold &> /dev/null; then
             echo "stellar-scaffold not found, installing..."
-            cargo install --git https://github.com/ahalabs/scaffold-stellar --branch main stellar-scaffold-cli
+            cargo binstall stellar-scaffold-cli
           else
             echo "stellar-scaffold already installed. Clear cache to force reinstall."
           fi


### PR DESCRIPTION
Use binstall rather than `cargo install` to speed up our builds on this repository. This also clears out a step that was added in a debug flow.