### PR TITLE
Add XDG config setting to our .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
- # The environment to use `development`, `testing`, `staging`, `production`
- STELLAR_SCAFFOLD_ENV=development
+# The environment to use `development`, `testing`, `staging`, `production`
+STELLAR_SCAFFOLD_ENV=development
+
+# Location of the config files for this project for the scaffold stellar CLI.
+# Learn more at https://developers.stellar.org/docs/tools/cli/stellar-cli#stellar-config-dir
+XDG_CONFIG_HOME=".config"
 
 # Prefix with "PUBLIC_" to make available in frontend files
 # Which Stellar network to use in the frontend: local, testnet, futurenet, or mainnet

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # stellar/soroban/Rust output
 target
 .soroban
-.stellar
+
+# project identity and alias files will be in .config/stellar
+.config
 
 # test snapshot folders from sample contracts
 test_snapshots


### PR DESCRIPTION
`stellar scaffold` expects accounts, aliases, etc to be in the project config dir. Update our .env.example to point to this directory so that upgrades etc work as expected for new users.